### PR TITLE
feat(no-dup-paths): each API path should be unique (#4)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,35 +2,25 @@
 
 _Please provide a description of the change here If there are associated issues, please reference them here._
 
+### Associated issue:
+
 ### Pull request (PR) check-list
 
 > **:white_check_mark: Please review and check the appropriate items.**
 
-1. **Type of change**
-<!-- Delete any unused types of change -->
-    - [ ] BREAKING CHANGE (with documentation) _Please explain if selected_
-    - [ ] Chore
-    - [ ] Defect (bug) fix (with regression tests)
-    - [ ] Documentation
-    - [ ] Feature/enhancement (with JavaDocs and/or Wiki article(s))
-    - [ ] Hotfix (with documentation)
-    - [ ] Performance improvement (with benchmarks)
-    - [ ] Refactoring (with catalog reference)
-    - [ ] Reversion
-    - [ ] Tests
-2. **Code standards compliance**
-    - [ ] Yes, `ESLint` passes.
-    - [ ] N/A (not applicable): _Please explain if selected_
-3. **Code quality**. Do the quality gateways pass with an "A" grade?
-    - [ ] `Complexity`
-    - [ ] `Duplications` (0.00%)
-    - [ ] `Issues` (0 issues or documentation for "won't fix" cases)
-    - [ ] `Maintainability`/`Technical Debt`
-    - [ ] `Reliability`
-    - [ ] `Security`
-    - [ ] N/A (not applicable). _Please explain if selected_
-4. **Test coverage**
-    - [ ] The source code is 100% covered with passing specs.
-    - [ ] N/A (not applicable). _Please explain if selected_
+1. **Code standards compliance**
+- [ ] Yes, `ESLint` passes.
+- [ ] N/A (not applicable): _Please explain if selected_
+2. **Code quality**. Do the quality gateways pass with an "A" grade?
+- [ ] `Complexity`
+- [ ] `Duplications` (0.00%)
+- [ ] `Issues` (0 issues or documentation for "won't fix" cases)
+- [ ] `Maintainability`/`Technical Debt`
+- [ ] `Reliability`
+- [ ] `Security`
+- [ ] N/A (not applicable). _Please explain if selected_
+3. **Test coverage**
+- [ ] The source code is 100% covered with passing specs.
+- [ ] N/A (not applicable). _Please explain if selected_
 
 > **:information_source: These tasks are not required to open a PR and can be done afterwards, or while the PR is open.**

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ $ eslint path/to/swagger/docs/** --fix
 
 | `options`        | Rule | Description| Status |
 |:----------------:|:-----|:-----------|:-------|
+|  | [`no-dup-paths`][no-dup-paths-url] | Each API `path` should be unique. <br><br><blockquote>For Swagger 1.2, this applies to both the Resource Listing and the API Declarations.  <br><br>For all versions, being unique is both based on verbatim equality and equivalency.  Example: `/pets/{id}` and `/pets/{petId}` are equivalently the same but not the same verbatim.</blockquote>  | In Progress<br>- Issue #4<br>- PR #10 |
 |  | [`no-path-verbs`][no-path-verbs-url] | Prohibit verbs in api paths | Completed |
 | :wrench: | [`require-plural-paths`][rule-plural-paths-url] | Require plural nouns in API paths | Completed |
 
@@ -120,7 +121,6 @@ The product backlog has lots of lonely `rules` looking for love from nice contri
 |  | [`require-array-items`](https://github.com/gregswindle/eslint-plugin-swagger-tools/issues/new?title=feat%28require-array-items%29%3A%20The%20%60items%60%20property%20is%20req...&labels[]=ESLint%3A%20Rule&labels[]=Status%3A%20Available&labels[]=Type%3A%20Feature) | The `items` property is required for all schemas/definitions of type `array`. _(See [swagger-api/swagger-spec/issues/174](https://github.com/swagger-api/swagger-spec/issues/174))_  | Available |
 |  | [`require-default-value`](https://github.com/gregswindle/eslint-plugin-swagger-tools/issues/new?title=feat%28require-default-value%29%3A%20Every%20place%20where%20a%20default...&labels[]=ESLint%3A%20Rule&labels[]=Status%3A%20Available&labels[]=Type%3A%20Feature) | Every place where a default value can be provided, the default value must validate against the corresponding schema/definition. _(This is not handled by JSON Schema validators, at least not the one I am using, so we have to do this manually.  See [json-schema/JSON-Schema-Test-Suite/pull/67](https://github.com/json-schema/JSON-Schema-Test-Suite/pull/67))_  | Available |
 |  | [`require-path-definition`](https://github.com/gregswindle/eslint-plugin-swagger-tools/issues/new?title=feat%28require-path-definition%29%3A%20For%20each%20API%20path%20parameter...&labels[]=ESLint%3A%20Rule&labels[]=Status%3A%20Available&labels[]=Type%3A%20Feature) | For each API path parameter, all operations for the API path require corresponding path parameter definitions or the corresponding path parameter needs to be in the path's parameters.  | Available |
-|  | [`require-unique-paths`](https://github.com/gregswindle/eslint-plugin-swagger-tools/issues/new?title=feat%28require-unique-paths%29%3A%20Each%20API%20%60path%60%20should%20be%20u...&labels[]=ESLint%3A%20Rule&labels[]=Status%3A%20Available&labels[]=Type%3A%20Feature) | Each API `path` should be unique. _(For Swagger 1.2, this applies to both the Resource Listing and the API Declarations.  For all versions, being unique is both based on verbatim equality and equivalency.  Example: `/pets/{id}` and `/pets/{petId}` are equivalently the same but not the same verbatim.)_  | Available |
 
 ## Contributions
 :family: We warmly welcome contributors. Check out the guidelines for [Contributing to `eslint-plugin-swagger-tools`](./.github/CONTRIBUTING.md) and our [Contributor Covenant Code of Conduct][code-of-conduct-url].
@@ -157,7 +157,7 @@ Contributions are stories with a beginning, a middle, and an end, all told throu
 [issues-url]: https://github.com/gregswindle/eslint-plugin-swagger-tools/issues
 [license-image]: https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square
 [license-url]: ./LICENSE
-[license-url]: ./LICENSE
+[no-dup-paths-url]: ./docs/rules/no-dup-paths.md
 [no-path-verbs-url]: ./docs/rules/no-path-verbs.md
 [nsp-img]: https://nodesecurity.io/orgs/gregswindle/projects/ebd8d503-2827-4444-a66e-c9b228bfa1c3/badge
 [nsp-url]: https://nodesecurity.io/orgs/gregswindle/projects/ebd8d503-2827-4444-a66e-c9b228bfa1c3

--- a/docs/rules/no-dup-paths.md
+++ b/docs/rules/no-dup-paths.md
@@ -1,0 +1,93 @@
+# each API path should be unique (`no-dup-paths`)
+
+All API paths in a Swagger specification should be unique.
+
+Uniqueness is not only based on **verbatim equality**, but also **functional equivalency**.
+
+
+## Rule Details
+
+This rule aims to ensure that API paths are literally and functionally unique.
+
+### Examples of _incorrect_ code for this rule:
+
+```js
+
+{
+  "paths": {
+    "/pets/{id}": ...,
+    "/pets/{id}": ...,
+    "/pets/{chipId}": ...,
+    "/pets/{petId}": ...,
+    "/pets/{uuid}": ...
+  }
+}
+
+```
+
+### Examples of _correct_ code for this rule:
+
+```js
+
+{
+  "paths": {
+    "/pets/{petId}": ...
+  }
+}
+
+```
+
+## When Not To Use It
+
+> ### :warning: This rule should always be enabled.
+
+In cases where your API path has a param that needs functional distinction, add a `query` input qualifier, e.g.,
+
+```http
+
+GET /pets/{id}?idType=aaha
+GET /pets/{id}?idType=petlink
+
+```
+
+For identifiers, create a [UUID][uuid-def-url] and create a model called `RegisteredId` that provides identifier semantics (if possible):
+
+```http
+
+GET /pets/{uuid}/registeredIds
+
+```
+
+Returns:
+
+```js
+
+[
+  {
+    "id": "11111111",
+    "type": "aaha",
+    "registrationAuthority": "American Animal Hospital Association",
+    "validFrom": 1326261600000,
+    "validTo": null
+  },
+  {
+    "id": "22222222",
+    "type": "petlink",
+    "registrationAuthority": "Datamars",
+    "validFrom": 1326261600000,
+    "validTo": null
+  }
+]
+
+```
+
+## Further Reading
+
+* [Rule source][rule-src-url]
+* [Rule specs][rule-specs-url]
+* [Documentation source][doc-src-url]
+
+[doc-src-url]: ./docs/rules/no-dup-paths.md
+[rule-specs-url]: ./tests/lib/rules/no-dup-paths.js
+[rule-src-url]: ./lib/rules/no-dup-paths.js
+[uuid-def-url]: https://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/lib/errors/lint-error.js
+++ b/lib/errors/lint-error.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const { capitalize } = require("lodash");
+
+class LintError extends Error {
+
+    constructor(message, fileName, lineNumber) {
+        super(message, fileName, lineNumber);
+        this.name = "LintError";
+    }
+
+}
+
+LintError.getContextMessage = (rule) => {
+    return `${rule.meta.docs.category}: ${capitalize(rule.meta.docs.description)}.`;
+};
+
+module.exports = LintError;

--- a/lib/errors/lint-error.js
+++ b/lib/errors/lint-error.js
@@ -1,7 +1,21 @@
 "use strict";
 
+
+/**
+ * Custom error object for Lint violations
+ * @extends Error
+ */
 class LintError extends Error {
 
+    /**
+     * Create a shadow LintError object
+     *
+     * @param {string} message    The error message
+     * @param {string} fileName   The name of the file where the error occurred
+     * @param {number} lineNumber The line number where the error was thrown
+     *
+     * @returns {LintError} A shadow LintError object
+     */
     constructor(message, fileName, lineNumber) {
         super(message, fileName, lineNumber);
         this.name = "LintError";
@@ -9,6 +23,13 @@ class LintError extends Error {
 
 }
 
+/**
+ * Provide a consistent, predictable message for context reports
+ *
+ * @param {Rule} rule An ESLint rule instance
+ *
+ * @returns {string} A message with rule category and description
+ */
 LintError.getContextMessage = (rule) => {
     return `${rule.meta.docs.category}: ${rule.meta.docs.description}.`;
 };

--- a/lib/errors/lint-error.js
+++ b/lib/errors/lint-error.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const { capitalize } = require("lodash");
-
 class LintError extends Error {
 
     constructor(message, fileName, lineNumber) {
@@ -12,7 +10,7 @@ class LintError extends Error {
 }
 
 LintError.getContextMessage = (rule) => {
-    return `${rule.meta.docs.category}: ${capitalize(rule.meta.docs.description)}.`;
+    return `${rule.meta.docs.category}: ${rule.meta.docs.description}.`;
 };
 
 module.exports = LintError;

--- a/lib/evaluators/path-evaluator.js
+++ b/lib/evaluators/path-evaluator.js
@@ -7,13 +7,25 @@ const { endsWith, startsWith } = require("lodash");
  */
 class PathEvaluator {
 
-   /**
-    * Determine whether a Literal Property represents an HTTP path
-    *
-    * @param {ASTNode<Literal>} node The node to be evaluated
-    *
-    * @returns {boolean} `true` if the value starts with "`/`"; otherwise,  `false`
-    */
+
+    /**
+     * Return the value of the path
+     *
+     * @param {ASTNode<Literal>} node The node to be evaluated
+     *
+     * @returns {string} The API path's value
+     */
+    getPathValue(node) {
+        return node.key.value;
+    }
+
+    /**
+     * Determine whether a Literal Property represents an HTTP path
+     *
+     * @param {ASTNode<Literal>} node The node to be evaluated
+     *
+     * @returns {boolean} `true` if the value starts with "`/`"; otherwise,  `false`
+     */
     isPath(node) {
         return startsWith(node.key.value, "/");
     }

--- a/lib/rules/no-dup-paths.js
+++ b/lib/rules/no-dup-paths.js
@@ -35,12 +35,26 @@ module.exports = {
 
         // any helper functions should go here or else delete this section
 
+        /**
+         * Return a generic path to identify duplicates
+         * @private
+         * @param {ASTNode<Property>} node The ASTNode to evaluate
+         *
+         * @returns {string} An API path with identical parameter values
+         */
         function replaceParamWithGeneric(node) {
             const path = pathEvaluator.getPathValue(node);
             const paramPtn = /(\{\w+\})/gi;
             return path.replace(paramPtn, "{X}");
         }
 
+        /**
+         * Add all API paths to the duplicatePaths array
+         * @private
+         * @param {ASTNode<Property>} node The ASTNode to evaluate
+         *
+         * @returns {void}
+         */
         function collectPaths(node) {
             if (pathEvaluator.isPath(node)) {
                 const genericPath = replaceParamWithGeneric(node);
@@ -52,6 +66,13 @@ module.exports = {
             }
         }
 
+        /**
+         * Determine whether a node's API paths have been defined more than once
+         *
+         * @param {ASTNode<Property>} node The ASTNode to evaluate
+         *
+         * @returns {boolean} `true` if duplicates exists; otherwise, `false`
+         */
         function isDuplicatePath(node) {
             const paths = filter(duplicatePaths, (comparatorObj) => {
                 const genericPath = replaceParamWithGeneric(node);

--- a/lib/rules/no-dup-paths.js
+++ b/lib/rules/no-dup-paths.js
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview each API path should be unique
+ * @author Greg Swindle
+ */
+"use strict";
+
+const LintError = require("../errors/lint-error");
+const PathEvaluator = require("../evaluators/path-evaluator");
+const { filter, includes } = require("lodash");
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "each API path should be unique",
+            category: "Best Practices",
+            recommended: false
+        },
+        fixable: null,  // or "code" or "whitespace"
+        schema: [
+            // fill in your schema
+        ]
+    },
+
+    create(context) {
+
+        // variables should be defined here
+        const pathEvaluator = new PathEvaluator();
+        const duplicatePaths = [];
+        //----------------------------------------------------------------------
+        // Helpers
+        //----------------------------------------------------------------------
+
+        // any helper functions should go here or else delete this section
+
+        function replaceParamWithGeneric(node) {
+            const path = pathEvaluator.getPathValue(node);
+            const paramPtn = /(\{\w+\})/gi;
+            return path.replace(paramPtn, "{X}");
+        }
+
+        function collectPaths(node) {
+            if (pathEvaluator.isPath(node)) {
+                const genericPath = replaceParamWithGeneric(node);
+                duplicatePaths.push({
+                    genericPath,
+                    node,
+                    path: pathEvaluator.getPathValue(node)
+                });
+            }
+        }
+
+        function isDuplicatePath(node) {
+            const paths = filter(duplicatePaths, (comparatorObj) => {
+                const genericPath = replaceParamWithGeneric(node);
+                return includes(comparatorObj.genericPath, genericPath);
+            });
+            return paths.length > 1;
+        }
+        //----------------------------------------------------------------------
+        // Public
+        //----------------------------------------------------------------------
+
+        return {
+
+            "Property[key.type=Literal]": (propertyNode) => {
+                collectPaths(propertyNode);
+            },
+
+            "Property[key.type=Literal]:exit": (propertyNode) => {
+                if (isDuplicatePath(propertyNode)) {
+                    context.report({
+                        node: propertyNode,
+                        message: LintError.getContextMessage(this),
+                        data: {
+                            identifier: pathEvaluator.getPathValue(propertyNode)
+                        }
+                    });
+                }
+            }
+
+        };
+    }
+};

--- a/lib/rules/no-path-verbs.js
+++ b/lib/rules/no-path-verbs.js
@@ -4,6 +4,7 @@
  */
 "use strict";
 
+const LintError = require("../errors/lint-error");
 const PathEvaluator = require("../evaluators/path-evaluator");
 const { drop, first, find, forEach, kebabCase, last, some, startsWith } = require("lodash");
 
@@ -72,14 +73,14 @@ module.exports = {
          *
          * @returns {void}
          */
-        function validatePathResources(node) {
+        function validatePathResources(node, rule) {
             if (pathEvaluator.isPath(node)) {
                 const path = pathEvaluator.getPathValue(node);
                 const resources = drop(path.split("/"));
                 if (some(resources, isVerb)) {
                     context.report({
                         node,
-                        message: "Best Practices: no verbs in API paths",
+                        message: LintError.getContextMessage(rule),
                         data: {
                             resources,
                             identifier: path
@@ -107,7 +108,7 @@ module.exports = {
          *
          * @returns {boolean} `true` whenever the last resource and its operationId start with the same strings.
          */
-        function pathContainsOperationId(node) {
+        function pathContainsOperationId(node, rule) {
             if (pathEvaluator.isPath(node)) {
                 const path = pathEvaluator.getPathValue(node);
                 const lastPathResource = last(path.split("/"));
@@ -120,7 +121,7 @@ module.exports = {
                     if (operationIdPrefix === lastPathResourcePrefix) {
                         context.report({
                             node,
-                            message: "Best Practices: no verbs in API paths",
+                            message: LintError.getContextMessage(rule),
                             data: {
                                 identifier: path
                             }
@@ -137,11 +138,11 @@ module.exports = {
         return {
 
             "Property[key.type=Literal]:exit": (propertyNode) => {
-                validatePathResources(propertyNode);
+                validatePathResources(propertyNode, this);
             },
 
             "Property[key.type=Literal][value.properties.length > 0]": (propertyNode) => {
-                pathContainsOperationId(propertyNode);
+                pathContainsOperationId(propertyNode, this);
             }
 
         };

--- a/lib/rules/no-path-verbs.js
+++ b/lib/rules/no-path-verbs.js
@@ -74,7 +74,7 @@ module.exports = {
          */
         function validatePathResources(node) {
             if (pathEvaluator.isPath(node)) {
-                const path = node.key.value;
+                const path = pathEvaluator.getPathValue(node);
                 const resources = drop(path.split("/"));
                 if (some(resources, isVerb)) {
                     context.report({
@@ -109,7 +109,7 @@ module.exports = {
          */
         function pathContainsOperationId(node) {
             if (pathEvaluator.isPath(node)) {
-                const path = node.key.value;
+                const path = pathEvaluator.getPathValue(node);
                 const lastPathResource = last(path.split("/"));
                 forEach(node.value.properties, (prop) => {
                     const operations = find(prop.value.properties, (prop) => {

--- a/lib/rules/no-path-verbs.js
+++ b/lib/rules/no-path-verbs.js
@@ -1,4 +1,3 @@
-/*eslint no-console: 0 */
 /**
  * @fileoverview prohibit use of verbs in api paths
  * @author Greg Swindle

--- a/lib/rules/require-plural-paths.js
+++ b/lib/rules/require-plural-paths.js
@@ -8,6 +8,7 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const LintError = require("../errors/lint-error");
 const PathEvaluator = require("../evaluators/path-evaluator");
 const _ = require("lodash");
 const pluralize = require("pluralize");
@@ -75,19 +76,6 @@ module.exports = {
         }
 
         /**
-         * Generate an error message with instructions to ammeliorate
-         * @private
-         * @param {ASTNode} node The ASTNode where the style violation occurred
-         *
-         * @returns {string} An error message with instructions to fix.
-         */
-        function toErrorMsg(node, resources) {
-            const invalidValue = node.key.value;
-            const validValue = fixPathResources(resources);
-            return `Style violation: API paths should have plural resources. Change resource "${invalidValue}" to "${validValue}" (or run eslint with the --fix flag) to automatically ensure style compliance.`;
-        }
-
-        /**
          * Determines whether any resources within an API path are singular,
          * and returns all invalid cases.
          * @private
@@ -95,14 +83,14 @@ module.exports = {
          *
          * @returns {void}
          */
-        function validatePathResources(node) {
+        function validatePathResources(node, rule) {
             if (pathEvaluator.isPath(node)) {
                 const path = pathEvaluator.getPathValue(node);
                 const resources = _.drop(path.split("/"));
                 if (_.some(resources, isInvalidPathEntry)) {
                     context.report({
                         node,
-                        message: toErrorMsg(node, resources),
+                        message: LintError.getContextMessage(rule),
                         data: {
                             resources,
                             identifier: path
@@ -122,7 +110,7 @@ module.exports = {
 
         return {
             "Property[key.type=Literal]:exit": (propertyNode) => {
-                validatePathResources(propertyNode);
+                validatePathResources(propertyNode, this);
             }
         };
     }

--- a/lib/rules/require-plural-paths.js
+++ b/lib/rules/require-plural-paths.js
@@ -97,7 +97,7 @@ module.exports = {
          */
         function validatePathResources(node) {
             if (pathEvaluator.isPath(node)) {
-                const path = node.key.value;
+                const path = pathEvaluator.getPathValue(node);
                 const resources = _.drop(path.split("/"));
                 if (_.some(resources, isInvalidPathEntry)) {
                     context.report({

--- a/tests/lib/errors/lint-error.spec.js
+++ b/tests/lib/errors/lint-error.spec.js
@@ -1,0 +1,27 @@
+"use strict";
+
+const { expect } = require("chai");
+const LintError = require("../../../lib/errors/lint-error");
+
+describe("LintError is a custom Error object that", () => {
+
+    const ruleMock = {
+        meta: {
+            docs: {
+                category: "Best Practices",
+                description: "a mock rule for this spec"
+            }
+        }
+    };
+
+    it("extends the Error object", () => {
+        const lintError = new LintError("Oops! Not good...");
+        expect(lintError.name).to.equal("LintError");
+        expect(lintError.message).to.equal("Oops! Not good...");
+    });
+
+    it("provides a standard error message for context reports", () => {
+        expect(LintError.getContextMessage(ruleMock)).to.equal("Best Practices: A mock rule for this spec.")
+    });
+
+});

--- a/tests/lib/errors/lint-error.spec.js
+++ b/tests/lib/errors/lint-error.spec.js
@@ -21,7 +21,7 @@ describe("LintError is a custom Error object that", () => {
     });
 
     it("provides a standard error message for context reports", () => {
-        expect(LintError.getContextMessage(ruleMock)).to.equal("Best Practices: a mock rule for this spec.")
+        expect(LintError.getContextMessage(ruleMock)).to.equal("Best Practices: a mock rule for this spec.");
     });
 
 });

--- a/tests/lib/errors/lint-error.spec.js
+++ b/tests/lib/errors/lint-error.spec.js
@@ -21,7 +21,7 @@ describe("LintError is a custom Error object that", () => {
     });
 
     it("provides a standard error message for context reports", () => {
-        expect(LintError.getContextMessage(ruleMock)).to.equal("Best Practices: A mock rule for this spec.")
+        expect(LintError.getContextMessage(ruleMock)).to.equal("Best Practices: a mock rule for this spec.")
     });
 
 });

--- a/tests/lib/evalutors/path-evaluator.spec.js
+++ b/tests/lib/evalutors/path-evaluator.spec.js
@@ -11,13 +11,18 @@ describe("evaluators are \"helper\" objects that provide common evaluation metho
     describe("PathEvaluator inspects Property[key.type=Literal] ASTNodes, and", () => {
 
         const pathEvaluator = new PathEvaluator();
+        const mockAstLiteralNode = {
+            key: {
+                value: "/pets/{id}/findByBreed"
+            }
+        };
+
+        it("returns the path's value", () => {
+            expect(pathEvaluator.getPathValue(mockAstLiteralNode)).to.equal("/pets/{id}/findByBreed");
+        });
 
         it("determines whether the node is a path", () => {
-            const mockAstLiteralNode = {
-                key: {
-                    value: "/pets/{id}/findByBreed"
-                }
-            };
+
             expect(pathEvaluator.isPath(mockAstLiteralNode)).to.equal(true);
 
             mockAstLiteralNode.key.value = "paths";

--- a/tests/lib/rules/no-dup-paths.js
+++ b/tests/lib/rules/no-dup-paths.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview each API path should be unique
+ * @author Greg Swindle
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-dup-paths"),
+    LintError = require("../../../lib/errors/lint-error"),
+    RuleTester = require("eslint").RuleTester;
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+const message = LintError.getContextMessage(rule);
+const ruleTester = new RuleTester();
+ruleTester.run("no-dup-paths", rule, {
+
+    valid: [{
+
+       code: " var swagger = {\"paths\":{\"/pets/{id}\":null,\"/pets/{id}/registeredIds\":null}}"
+
+    }],
+
+    invalid: [
+        {
+            code: " var swagger = {\"paths\":{\"/pets/{id}\":null,\"/pets/{id}\":null}}",
+            errors: [{
+                message: message,
+                type: "Property"
+            }]
+        },
+        {
+            code: " var swagger = {\"paths\":{\"/pets/{id}\":null,\"/pets/{uuid}\":null}}",
+            errors: [{
+                message: message,
+                type: "Property"
+            }]
+        },
+        {
+            code: " var swagger = {\"paths\":{\"/pets/{id}/vaccinations/{vaccineId}\":null,\"/pets/{uuid}/vaccinations/{iupacId}\":null}}",
+            errors: [{
+                message: message,
+                type: "Property"
+            }]
+        }
+    ]
+});

--- a/tests/lib/rules/no-dup-paths.js
+++ b/tests/lib/rules/no-dup-paths.js
@@ -22,7 +22,7 @@ ruleTester.run("no-dup-paths", rule, {
 
     valid: [{
 
-       code: " var swagger = {\"paths\":{\"/pets/{id}\":null,\"/pets/{id}/registeredIds\":null}}"
+        code: " var swagger = {\"paths\":{\"/pets/{id}\":null,\"/pets/{id}/registeredIds\":null}}"
 
     }],
 
@@ -30,21 +30,21 @@ ruleTester.run("no-dup-paths", rule, {
         {
             code: " var swagger = {\"paths\":{\"/pets/{id}\":null,\"/pets/{id}\":null}}",
             errors: [{
-                message: message,
+                message,
                 type: "Property"
             }]
         },
         {
             code: " var swagger = {\"paths\":{\"/pets/{id}\":null,\"/pets/{uuid}\":null}}",
             errors: [{
-                message: message,
+                message,
                 type: "Property"
             }]
         },
         {
             code: " var swagger = {\"paths\":{\"/pets/{id}/vaccinations/{vaccineId}\":null,\"/pets/{uuid}/vaccinations/{iupacId}\":null}}",
             errors: [{
-                message: message,
+                message,
                 type: "Property"
             }]
         }

--- a/tests/lib/rules/no-path-verbs.js
+++ b/tests/lib/rules/no-path-verbs.js
@@ -30,13 +30,13 @@ ruleTester.run("no-path-verbs", rule, {
         {
             code: "var spec = {\"swagger\":\"2.0\",\"paths\":{\"/users/{id}/logout\":{\"get\":{\"operationId\":\"logoutUser\"}}}}",
             errors: [{
-                message: "Best Practices: no verbs in API paths"
+                message: "Best Practices: prohibit use of verbs in api paths."
             }]
         },
         {
             code: "var spec = {\"swagger\":\"2.0\",\"paths\":{\"/pets/addPet\":null}}",
             errors: [{
-                message: "Best Practices: no verbs in API paths"
+                message: "Best Practices: prohibit use of verbs in api paths."
             }]
         }
     ]

--- a/tests/lib/rules/require-plural-paths.js
+++ b/tests/lib/rules/require-plural-paths.js
@@ -64,7 +64,7 @@ function createExpectedErrorMessages() {
     }];
     return map(paths, (path) => {
         return {
-            message: msg.replace("INVALID_VAL", path.invalid).replace("VALID_VAL", path.valid)
+            message: "Stylistic Issues: require plural nouns in API paths."
         };
     });
 }

--- a/tests/lib/rules/require-plural-paths.js
+++ b/tests/lib/rules/require-plural-paths.js
@@ -18,7 +18,6 @@ var { map } = require("lodash"),
 //------------------------------------------------------------------------------
 
 function createExpectedErrorMessages() {
-    const msg = "Style violation: API paths should have plural resources. Change resource \"INVALID_VAL\" to \"VALID_VAL\" (or run eslint with the --fix flag) to automatically ensure style compliance.";
     const paths = [{
         "invalid": "/pet",
         "valid": "/pets"
@@ -62,7 +61,7 @@ function createExpectedErrorMessages() {
         "invalid": "/user/{username}",
         "valid": "/users/{username}"
     }];
-    return map(paths, (path) => {
+    return map(paths, () => {
         return {
             message: "Stylistic Issues: require plural nouns in API paths."
         };


### PR DESCRIPTION
## Description of change

Require all API paths to be literally and equivalently unique.

### Associated issue: #4

### Pull request (PR) check-list

> **:white_check_mark: Please review and check the appropriate items.**

1. **Code standards compliance**
- [x] Yes, `ESLint` passes.
2. **Code quality**. Do the quality gateways pass with an "A" grade?
- [x] `Complexity`
- [x] `Duplications` (0.00%)
- [x] `Issues` (0 issues or documentation for "won't fix" cases)
- [x] `Maintainability`/`Technical Debt`
- [x] `Reliability`
- [x] `Security`
3. **Test coverage**
- [x] The source code is 100% covered with passing specs.

> **:information_source: These tasks are not required to open a PR and can be done afterwards, or while the PR is open.**
